### PR TITLE
Support downloading from "dumb http" with git-annex.

### DIFF
--- a/modules/git/command.go
+++ b/modules/git/command.go
@@ -292,12 +292,13 @@ func (c *Command) RunStdBytes(opts *RunOpts) (stdout, stderr []byte, runErr RunS
 }
 
 // AllowLFSFiltersArgs return globalCommandArgs with lfs filter, it should only be used for tests
+// It also re-enables git-credential(1), which is used to test git-annex's HTTP support
 func AllowLFSFiltersArgs() []string {
 	// Now here we should explicitly allow lfs filters to run
 	filteredLFSGlobalArgs := make([]string, len(globalCommandArgs))
 	j := 0
 	for _, arg := range globalCommandArgs {
-		if strings.Contains(arg, "lfs") {
+		if strings.Contains(arg, "lfs") || strings.Contains(arg, "credential") {
 			j--
 		} else {
 			filteredLFSGlobalArgs[j] = arg

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1255,6 +1255,7 @@ func RegisterRoutes(m *web.Route) {
 				m.PostOptions("/git-receive-pack", repo.ServiceReceivePack)
 				m.GetOptions("/info/refs", repo.GetInfoRefs)
 				m.GetOptions("/HEAD", repo.GetTextFile("HEAD"))
+				m.GetOptions("/config", repo.GetTextFile("config"))  // needed by git-annex's dumb http mode
 				m.GetOptions("/objects/info/alternates", repo.GetTextFile("objects/info/alternates"))
 				m.GetOptions("/objects/info/http-alternates", repo.GetTextFile("objects/info/http-alternates"))
 				m.GetOptions("/objects/info/packs", repo.GetInfoPacks)
@@ -1262,6 +1263,7 @@ func RegisterRoutes(m *web.Route) {
 				m.GetOptions("/objects/{head:[0-9a-f]{2}}/{hash:[0-9a-f]{38}}", repo.GetLooseObject)
 				m.GetOptions("/objects/pack/pack-{file:[0-9a-f]{40}}.pack", repo.GetPackFile)
 				m.GetOptions("/objects/pack/pack-{file:[0-9a-f]{40}}.idx", repo.GetIdxFile)
+				m.GetOptions("/annex/objects/{hash1}/{hash2}/{keyDir}/{key}", repo.GetAnnexObject) // for git-annex
 			}, ignSignInAndCsrf, context_service.UserAssignmentWeb())
 		})
 	})

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -282,6 +282,13 @@ func RegisterRoutes(m *web.Route) {
 		}
 	}
 
+	annexEnabled := func(ctx *context.Context) {
+		if !setting.Annex.Enabled {
+			ctx.Error(http.StatusNotFound)
+			return
+		}
+	}
+
 	federationEnabled := func(ctx *context.Context) {
 		if !setting.Federation.Enabled {
 			ctx.Error(http.StatusNotFound)
@@ -1251,11 +1258,16 @@ func RegisterRoutes(m *web.Route) {
 			}, ignSignInAndCsrf, lfsServerEnabled)
 
 			m.Group("", func() {
+				// for git-annex
+				m.GetOptions("/config", repo.GetTextFile("config"))  // needed by clients reading annex.uuid during `git annex initremote`
+				m.GetOptions("/annex/objects/{hash1}/{hash2}/{keyDir}/{key}", repo.GetAnnexObject)
+			}, ignSignInAndCsrf, annexEnabled, context_service.UserAssignmentWeb())
+
+			m.Group("", func() {
 				m.PostOptions("/git-upload-pack", repo.ServiceUploadPack)
 				m.PostOptions("/git-receive-pack", repo.ServiceReceivePack)
 				m.GetOptions("/info/refs", repo.GetInfoRefs)
 				m.GetOptions("/HEAD", repo.GetTextFile("HEAD"))
-				m.GetOptions("/config", repo.GetTextFile("config"))  // needed by git-annex's dumb http mode
 				m.GetOptions("/objects/info/alternates", repo.GetTextFile("objects/info/alternates"))
 				m.GetOptions("/objects/info/http-alternates", repo.GetTextFile("objects/info/http-alternates"))
 				m.GetOptions("/objects/info/packs", repo.GetInfoPacks)
@@ -1263,7 +1275,6 @@ func RegisterRoutes(m *web.Route) {
 				m.GetOptions("/objects/{head:[0-9a-f]{2}}/{hash:[0-9a-f]{38}}", repo.GetLooseObject)
 				m.GetOptions("/objects/pack/pack-{file:[0-9a-f]{40}}.pack", repo.GetPackFile)
 				m.GetOptions("/objects/pack/pack-{file:[0-9a-f]{40}}.idx", repo.GetIdxFile)
-				m.GetOptions("/annex/objects/{hash1}/{hash2}/{keyDir}/{key}", repo.GetAnnexObject) // for git-annex
 			}, ignSignInAndCsrf, context_service.UserAssignmentWeb())
 		})
 	})

--- a/services/auth/auth.go
+++ b/services/auth/auth.go
@@ -51,6 +51,20 @@ func isGitRawReleaseOrLFSPath(req *http.Request) bool {
 	return false
 }
 
+var (
+	annexPathRe = regexp.MustCompile(`^/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+/annex/`)
+)
+
+func isAnnexPath(req *http.Request) bool {
+	//if setting.Annex.Enabled { // TODO
+	if true {
+		// "/config" is git's config, not specifically git-annex's; but the only current
+		// user of it is when git-annex downloads the annex.uuid during 'git annex init'.
+		return strings.HasSuffix(req.URL.Path, "/config") || annexPathRe.MatchString(req.URL.Path)
+	}
+	return false
+}
+
 // handleSignIn clears existing session variables and stores new ones for the specified user object
 func handleSignIn(resp http.ResponseWriter, req *http.Request, sess SessionStore, user *user_model.User) {
 	// We need to regenerate the session...

--- a/services/auth/basic.go
+++ b/services/auth/basic.go
@@ -42,8 +42,8 @@ func (b *Basic) Name() string {
 // name/token on successful validation.
 // Returns nil if header is empty or validation fails.
 func (b *Basic) Verify(req *http.Request, w http.ResponseWriter, store DataStore, sess SessionStore) *user_model.User {
-	// Basic authentication should only fire on API, Download or on Git or LFSPaths
-	if !middleware.IsAPIPath(req) && !isContainerPath(req) && !isAttachmentDownload(req) && !isGitRawReleaseOrLFSPath(req) {
+	// Basic authentication should only fire on API, Download or on Git, LFSPaths or Git-Annex paths
+	if !middleware.IsAPIPath(req) && !isContainerPath(req) && !isAttachmentDownload(req) && !isGitRawReleaseOrLFSPath(req) && !isAnnexPath(req) {
 		return nil
 	}
 

--- a/tests/integration/git_annex_test.go
+++ b/tests/integration/git_annex_test.go
@@ -51,7 +51,8 @@ func doCreateRemoteAnnexRepository(t *testing.T, u *url.URL, ctx APITestContext,
 /*
  Test that permissions are enforced on git-annex-shell commands.
 
- Along the way, test that uploading, downloading, and deleting all work.
+ Along the way, this also tests that uploading, downloading, and deleting all work,
+ so we haven't written separate tests for those.
 */
 func TestGitAnnexPermissions(t *testing.T) {
 	if !setting.Annex.Enabled {
@@ -68,6 +69,16 @@ func TestGitAnnexPermissions(t *testing.T) {
 
 	onGiteaRun(t, func(t *testing.T, u *url.URL) {
 
+		// Tell git-annex to allow http://127.0.0.1, http://localhost and http://::1. Without
+		// this, all `git annex` commands will silently fail when run against http:// remotes
+		// without explaining what's wrong.
+		//
+		// Note: onGiteaRun() sets up an alternate HOME so this actually edits
+		//       tests/integration/gitea-integration-*/data/home/.gitconfig and
+		//       if you're debugging you need to remember to match that.
+		_, _, err := git.NewCommandNoGlobals("config", "--global", "annex.security.allowed-ip-addresses", "all").RunStdString(&git.RunOpts{})
+		require.NoError(t, err)
+
 		t.Run("Public", func(t *testing.T) {
 			defer tests.PrintCurrentTest(t)()
 
@@ -80,8 +91,6 @@ func TestGitAnnexPermissions(t *testing.T) {
 			require.NoError(t, err)
 			require.False(t, repo.IsPrivate)
 
-			// Remote addresses of the repo
-			repoURL := createSSHUrl(ownerCtx.GitPath(), u)                        // remote git URL
 			remoteRepoPath := path.Join(setting.RepoRootPath, ownerCtx.GitPath()) // path on disk -- which can be examined directly because we're testing from localhost
 
 			// Different sessions, so we can test different permissions.
@@ -102,6 +111,8 @@ func TestGitAnnexPermissions(t *testing.T) {
 
 				t.Run("SSH", func(t *testing.T) {
 					defer tests.PrintCurrentTest(t)()
+
+					repoURL := createSSHUrl(ownerCtx.GitPath(), u)
 
 					repoPath := path.Join(t.TempDir(), ownerCtx.Reponame)
 					defer util.RemoveAll(repoPath) // cleans out git-annex lockdown permissions
@@ -130,6 +141,31 @@ func TestGitAnnexPermissions(t *testing.T) {
 						})
 					})
 				})
+
+				t.Run("HTTP", func(t *testing.T) {
+					defer tests.PrintCurrentTest(t)()
+
+					repoURL := createHTTPUrl(ownerCtx.GitPath(), u)
+
+					repoPath := path.Join(t.TempDir(), ownerCtx.Reponame)
+					defer util.RemoveAll(repoPath) // cleans out git-annex lockdown permissions
+
+					withAnnexCtxHTTPPassword(t, u, ownerCtx, func() {
+						doGitClone(repoPath, repoURL)(t)
+					})
+
+					withAnnexCtxHTTPPassword(t, u, ownerCtx, func() {
+						t.Run("Init", func(t *testing.T) {
+							defer tests.PrintCurrentTest(t)()
+							require.NoError(t, doAnnexInitTest(remoteRepoPath, repoPath))
+						})
+
+						t.Run("Download", func(t *testing.T) {
+							defer tests.PrintCurrentTest(t)()
+							require.NoError(t, doAnnexDownloadTest(remoteRepoPath, repoPath))
+						})
+					})
+				})
 			})
 
 			t.Run("Writer", func(t *testing.T) {
@@ -137,6 +173,8 @@ func TestGitAnnexPermissions(t *testing.T) {
 
 				t.Run("SSH", func(t *testing.T) {
 					defer tests.PrintCurrentTest(t)()
+
+					repoURL := createSSHUrl(ownerCtx.GitPath(), u)
 
 					repoPath := path.Join(t.TempDir(), ownerCtx.Reponame)
 					defer util.RemoveAll(repoPath) // cleans out git-annex lockdown permissions
@@ -165,6 +203,31 @@ func TestGitAnnexPermissions(t *testing.T) {
 						})
 					})
 				})
+
+				t.Run("HTTP", func(t *testing.T) {
+					defer tests.PrintCurrentTest(t)()
+
+					repoURL := createHTTPUrl(ownerCtx.GitPath(), u)
+
+					repoPath := path.Join(t.TempDir(), ownerCtx.Reponame)
+					defer util.RemoveAll(repoPath) // cleans out git-annex lockdown permissions
+
+					withAnnexCtxHTTPPassword(t, u, ownerCtx, func() {
+						doGitClone(repoPath, repoURL)(t)
+					})
+
+					withAnnexCtxHTTPPassword(t, u, writerCtx, func() {
+						t.Run("Init", func(t *testing.T) {
+							defer tests.PrintCurrentTest(t)()
+							require.NoError(t, doAnnexInitTest(remoteRepoPath, repoPath))
+						})
+
+						t.Run("Download", func(t *testing.T) {
+							defer tests.PrintCurrentTest(t)()
+							require.NoError(t, doAnnexDownloadTest(remoteRepoPath, repoPath))
+						})
+					})
+				})
 			})
 
 			t.Run("Reader", func(t *testing.T) {
@@ -172,6 +235,8 @@ func TestGitAnnexPermissions(t *testing.T) {
 
 				t.Run("SSH", func(t *testing.T) {
 					defer tests.PrintCurrentTest(t)()
+
+					repoURL := createSSHUrl(ownerCtx.GitPath(), u)
 
 					repoPath := path.Join(t.TempDir(), ownerCtx.Reponame)
 					defer util.RemoveAll(repoPath) // cleans out git-annex lockdown permissions
@@ -200,6 +265,31 @@ func TestGitAnnexPermissions(t *testing.T) {
 						})
 					})
 				})
+
+				t.Run("HTTP", func(t *testing.T) {
+					defer tests.PrintCurrentTest(t)()
+
+					repoURL := createHTTPUrl(ownerCtx.GitPath(), u)
+
+					repoPath := path.Join(t.TempDir(), ownerCtx.Reponame)
+					defer util.RemoveAll(repoPath) // cleans out git-annex lockdown permissions
+
+					withAnnexCtxHTTPPassword(t, u, ownerCtx, func() {
+						doGitClone(repoPath, repoURL)(t)
+					})
+
+					withAnnexCtxHTTPPassword(t, u, readerCtx, func() {
+						t.Run("Init", func(t *testing.T) {
+							defer tests.PrintCurrentTest(t)()
+							require.NoError(t, doAnnexInitTest(remoteRepoPath, repoPath))
+						})
+
+						t.Run("Download", func(t *testing.T) {
+							defer tests.PrintCurrentTest(t)()
+							require.NoError(t, doAnnexDownloadTest(remoteRepoPath, repoPath))
+						})
+					})
+				})
 			})
 
 			t.Run("Outsider", func(t *testing.T) {
@@ -207,6 +297,8 @@ func TestGitAnnexPermissions(t *testing.T) {
 
 				t.Run("SSH", func(t *testing.T) {
 					defer tests.PrintCurrentTest(t)()
+
+					repoURL := createSSHUrl(ownerCtx.GitPath(), u)
 
 					repoPath := path.Join(t.TempDir(), ownerCtx.Reponame)
 					defer util.RemoveAll(repoPath) // cleans out git-annex lockdown permissions
@@ -235,6 +327,61 @@ func TestGitAnnexPermissions(t *testing.T) {
 						})
 					})
 				})
+
+				t.Run("HTTP", func(t *testing.T) {
+					defer tests.PrintCurrentTest(t)()
+
+					repoURL := createHTTPUrl(ownerCtx.GitPath(), u)
+
+					repoPath := path.Join(t.TempDir(), ownerCtx.Reponame)
+					defer util.RemoveAll(repoPath) // cleans out git-annex lockdown permissions
+
+					withAnnexCtxHTTPPassword(t, u, ownerCtx, func() {
+						doGitClone(repoPath, repoURL)(t)
+					})
+
+					withAnnexCtxHTTPPassword(t, u, outsiderCtx, func() {
+						t.Run("Init", func(t *testing.T) {
+							defer tests.PrintCurrentTest(t)()
+							require.NoError(t, doAnnexInitTest(remoteRepoPath, repoPath))
+						})
+
+						t.Run("Download", func(t *testing.T) {
+							defer tests.PrintCurrentTest(t)()
+							require.NoError(t, doAnnexDownloadTest(remoteRepoPath, repoPath))
+						})
+					})
+				})
+			})
+
+			t.Run("Anonymous", func(t *testing.T) {
+				defer tests.PrintCurrentTest(t)()
+
+				// Only HTTP has an anonymous mode
+				t.Run("HTTP", func(t *testing.T) {
+					defer tests.PrintCurrentTest(t)()
+
+					repoURL := createHTTPUrl(ownerCtx.GitPath(), u)
+
+					repoPath := path.Join(t.TempDir(), ownerCtx.Reponame)
+					defer util.RemoveAll(repoPath) // cleans out git-annex lockdown permissions
+
+					withAnnexCtxHTTPPassword(t, u, ownerCtx, func() {
+						doGitClone(repoPath, repoURL)(t)
+					})
+
+					// unlike the other tests, at this step we *do not* define credentials:
+
+					t.Run("Init", func(t *testing.T) {
+						defer tests.PrintCurrentTest(t)()
+						require.NoError(t, doAnnexInitTest(remoteRepoPath, repoPath))
+					})
+
+					t.Run("Download", func(t *testing.T) {
+						defer tests.PrintCurrentTest(t)()
+						require.NoError(t, doAnnexDownloadTest(remoteRepoPath, repoPath))
+					})
+				})
 			})
 
 			t.Run("Delete", func(t *testing.T) {
@@ -259,8 +406,6 @@ func TestGitAnnexPermissions(t *testing.T) {
 			require.NoError(t, err)
 			require.True(t, repo.IsPrivate)
 
-			// Remote addresses of the repo
-			repoURL := createSSHUrl(ownerCtx.GitPath(), u)                        // remote git URL
 			remoteRepoPath := path.Join(setting.RepoRootPath, ownerCtx.GitPath()) // path on disk -- which can be examined directly because we're testing from localhost
 
 			// Different sessions, so we can test different permissions.
@@ -283,6 +428,8 @@ func TestGitAnnexPermissions(t *testing.T) {
 
 				t.Run("SSH", func(t *testing.T) {
 					defer tests.PrintCurrentTest(t)()
+
+					repoURL := createSSHUrl(ownerCtx.GitPath(), u)
 
 					repoPath := path.Join(t.TempDir(), ownerCtx.Reponame)
 					defer util.RemoveAll(repoPath) // cleans out git-annex lockdown permissions
@@ -311,6 +458,31 @@ func TestGitAnnexPermissions(t *testing.T) {
 						})
 					})
 				})
+
+				t.Run("HTTP", func(t *testing.T) {
+					defer tests.PrintCurrentTest(t)()
+
+					repoURL := createHTTPUrl(ownerCtx.GitPath(), u)
+
+					repoPath := path.Join(t.TempDir(), ownerCtx.Reponame)
+					defer util.RemoveAll(repoPath) // cleans out git-annex lockdown permissions
+
+					withAnnexCtxHTTPPassword(t, u, ownerCtx, func() {
+						doGitClone(repoPath, repoURL)(t)
+					})
+
+					withAnnexCtxHTTPPassword(t, u, ownerCtx, func() {
+						t.Run("Init", func(t *testing.T) {
+							defer tests.PrintCurrentTest(t)()
+							require.NoError(t, doAnnexInitTest(remoteRepoPath, repoPath))
+						})
+
+						t.Run("Download", func(t *testing.T) {
+							defer tests.PrintCurrentTest(t)()
+							require.NoError(t, doAnnexDownloadTest(remoteRepoPath, repoPath))
+						})
+					})
+				})
 			})
 
 			t.Run("Writer", func(t *testing.T) {
@@ -318,6 +490,8 @@ func TestGitAnnexPermissions(t *testing.T) {
 
 				t.Run("SSH", func(t *testing.T) {
 					defer tests.PrintCurrentTest(t)()
+
+					repoURL := createSSHUrl(ownerCtx.GitPath(), u)
 
 					repoPath := path.Join(t.TempDir(), ownerCtx.Reponame)
 					defer util.RemoveAll(repoPath) // cleans out git-annex lockdown permissions
@@ -346,6 +520,31 @@ func TestGitAnnexPermissions(t *testing.T) {
 						})
 					})
 				})
+
+				t.Run("HTTP", func(t *testing.T) {
+					defer tests.PrintCurrentTest(t)()
+
+					repoURL := createHTTPUrl(ownerCtx.GitPath(), u)
+
+					repoPath := path.Join(t.TempDir(), ownerCtx.Reponame)
+					defer util.RemoveAll(repoPath) // cleans out git-annex lockdown permissions
+
+					withAnnexCtxHTTPPassword(t, u, ownerCtx, func() {
+						doGitClone(repoPath, repoURL)(t)
+					})
+
+					withAnnexCtxHTTPPassword(t, u, writerCtx, func() {
+						t.Run("Init", func(t *testing.T) {
+							defer tests.PrintCurrentTest(t)()
+							require.NoError(t, doAnnexInitTest(remoteRepoPath, repoPath))
+						})
+
+						t.Run("Download", func(t *testing.T) {
+							defer tests.PrintCurrentTest(t)()
+							require.NoError(t, doAnnexDownloadTest(remoteRepoPath, repoPath))
+						})
+					})
+				})
 			})
 
 			t.Run("Reader", func(t *testing.T) {
@@ -353,6 +552,8 @@ func TestGitAnnexPermissions(t *testing.T) {
 
 				t.Run("SSH", func(t *testing.T) {
 					defer tests.PrintCurrentTest(t)()
+
+					repoURL := createSSHUrl(ownerCtx.GitPath(), u)
 
 					repoPath := path.Join(t.TempDir(), ownerCtx.Reponame)
 					defer util.RemoveAll(repoPath) // cleans out git-annex lockdown permissions
@@ -381,6 +582,31 @@ func TestGitAnnexPermissions(t *testing.T) {
 						})
 					})
 				})
+
+				t.Run("HTTP", func(t *testing.T) {
+					defer tests.PrintCurrentTest(t)()
+
+					repoURL := createHTTPUrl(ownerCtx.GitPath(), u)
+
+					repoPath := path.Join(t.TempDir(), ownerCtx.Reponame)
+					defer util.RemoveAll(repoPath) // cleans out git-annex lockdown permissions
+
+					withAnnexCtxHTTPPassword(t, u, ownerCtx, func() {
+						doGitClone(repoPath, repoURL)(t)
+					})
+
+					withAnnexCtxHTTPPassword(t, u, readerCtx, func() {
+						t.Run("Init", func(t *testing.T) {
+							defer tests.PrintCurrentTest(t)()
+							require.NoError(t, doAnnexInitTest(remoteRepoPath, repoPath))
+						})
+
+						t.Run("Download", func(t *testing.T) {
+							defer tests.PrintCurrentTest(t)()
+							require.NoError(t, doAnnexDownloadTest(remoteRepoPath, repoPath))
+						})
+					})
+				})
 			})
 
 			t.Run("Outsider", func(t *testing.T) {
@@ -388,6 +614,8 @@ func TestGitAnnexPermissions(t *testing.T) {
 
 				t.Run("SSH", func(t *testing.T) {
 					defer tests.PrintCurrentTest(t)()
+
+					repoURL := createSSHUrl(ownerCtx.GitPath(), u)
 
 					repoPath := path.Join(t.TempDir(), ownerCtx.Reponame)
 					defer util.RemoveAll(repoPath) // cleans out git-annex lockdown permissions
@@ -416,6 +644,61 @@ func TestGitAnnexPermissions(t *testing.T) {
 						})
 					})
 				})
+
+				t.Run("HTTP", func(t *testing.T) {
+					defer tests.PrintCurrentTest(t)()
+
+					repoURL := createHTTPUrl(ownerCtx.GitPath(), u)
+
+					repoPath := path.Join(t.TempDir(), ownerCtx.Reponame)
+					defer util.RemoveAll(repoPath) // cleans out git-annex lockdown permissions
+
+					withAnnexCtxHTTPPassword(t, u, ownerCtx, func() {
+						doGitClone(repoPath, repoURL)(t)
+					})
+
+					withAnnexCtxHTTPPassword(t, u, outsiderCtx, func() {
+						t.Run("Init", func(t *testing.T) {
+							defer tests.PrintCurrentTest(t)()
+							require.Error(t, doAnnexInitTest(remoteRepoPath, repoPath))
+						})
+
+						t.Run("Download", func(t *testing.T) {
+							defer tests.PrintCurrentTest(t)()
+							require.Error(t, doAnnexDownloadTest(remoteRepoPath, repoPath))
+						})
+					})
+				})
+			})
+
+			t.Run("Anonymous", func(t *testing.T) {
+				defer tests.PrintCurrentTest(t)()
+
+				// Only HTTP has an anonymous mode
+				t.Run("HTTP", func(t *testing.T) {
+					defer tests.PrintCurrentTest(t)()
+
+					repoURL := createHTTPUrl(ownerCtx.GitPath(), u)
+
+					repoPath := path.Join(t.TempDir(), ownerCtx.Reponame)
+					defer util.RemoveAll(repoPath) // cleans out git-annex lockdown permissions
+
+					withAnnexCtxHTTPPassword(t, u, ownerCtx, func() {
+						doGitClone(repoPath, repoURL)(t)
+					})
+
+					// unlike the other tests, at this step we *do not* define credentials:
+
+					t.Run("Init", func(t *testing.T) {
+						defer tests.PrintCurrentTest(t)()
+						require.Error(t, doAnnexInitTest(remoteRepoPath, repoPath))
+					})
+
+					t.Run("Download", func(t *testing.T) {
+						defer tests.PrintCurrentTest(t)()
+						require.Error(t, doAnnexDownloadTest(remoteRepoPath, repoPath))
+					})
+				})
 			})
 
 			t.Run("Delete", func(t *testing.T) {
@@ -437,7 +720,7 @@ precondition: repoPath contains a pre-cloned git repo with an annex: a valid git
 
 */
 func doAnnexInitTest(remoteRepoPath string, repoPath string) (err error) {
-	_, _, err = git.NewCommand(git.DefaultContext, "annex", "init").RunStdString(&git.RunOpts{Dir: repoPath})
+	_, _, err = git.NewCommandNoGlobals("annex", "init").RunStdString(&git.RunOpts{Dir: repoPath})
 	if err != nil {
 		return fmt.Errorf("Couldn't `git annex init`: %w", err)
 	}
@@ -445,7 +728,7 @@ func doAnnexInitTest(remoteRepoPath string, repoPath string) (err error) {
 	// - method 0: 'git config remote.origin.annex-uuid'.
 	//   Demonstrates that 'git annex init' successfully contacted
 	//   the remote git-annex and was able to learn its ID number.
-	readAnnexUUID, _, err := git.NewCommand(git.DefaultContext, "config", "remote.origin.annex-uuid").RunStdString(&git.RunOpts{Dir: repoPath})
+	readAnnexUUID, _, err := git.NewCommandNoGlobals("config", "remote.origin.annex-uuid").RunStdString(&git.RunOpts{Dir: repoPath})
 	if err != nil {
 		return fmt.Errorf("Couldn't read remote `git config remote.origin.annex-uuid`: %w", err)
 	}
@@ -456,7 +739,7 @@ func doAnnexInitTest(remoteRepoPath string, repoPath string) (err error) {
 		return errors.New(fmt.Sprintf("'git config remote.origin.annex-uuid' should have been able to download the remote's uuid; but instead read '%s'.", readAnnexUUID))
 	}
 
-	remoteAnnexUUID, _, err := git.NewCommand(git.DefaultContext, "config", "annex.uuid").RunStdString(&git.RunOpts{Dir: remoteRepoPath})
+	remoteAnnexUUID, _, err := git.NewCommandNoGlobals("config", "annex.uuid").RunStdString(&git.RunOpts{Dir: remoteRepoPath})
 	if err != nil {
 		return fmt.Errorf("Couldn't read local `git config annex.uuid`: %w", err)
 	}
@@ -473,7 +756,7 @@ func doAnnexInitTest(remoteRepoPath string, repoPath string) (err error) {
 
 	// - method 1: 'git annex whereis'.
 	//   Demonstrates that git-annex understands the annexed file can be found in the remote annex.
-	annexWhereis, _, err := git.NewCommand(git.DefaultContext, "annex", "whereis", "large.bin").RunStdString(&git.RunOpts{Dir: repoPath})
+	annexWhereis, _, err := git.NewCommandNoGlobals("annex", "whereis", "large.bin").RunStdString(&git.RunOpts{Dir: repoPath})
 	if err != nil {
 		return fmt.Errorf("Couldn't `git annex whereis large.bin`: %w", err)
 	}
@@ -492,7 +775,7 @@ func doAnnexDownloadTest(remoteRepoPath string, repoPath string) (err error) {
 	//     "git annex copy" will notice and run "git annex init", silently.
 	//     This shouldn't change any results, but be aware in case it does.
 
-	_, _, err = git.NewCommand(git.DefaultContext, "annex", "copy", "--from", "origin").RunStdString(&git.RunOpts{Dir: repoPath})
+	_, _, err = git.NewCommandNoGlobals("annex", "copy", "--from", "origin").RunStdString(&git.RunOpts{Dir: repoPath})
 	if err != nil {
 		return err
 	}
@@ -540,12 +823,12 @@ func doAnnexUploadTest(remoteRepoPath string, repoPath string) (err error) {
 		return err
 	}
 
-	_, _, err = git.NewCommand(git.DefaultContext, "annex", "copy", "--to", "origin").RunStdString(&git.RunOpts{Dir: repoPath})
+	_, _, err = git.NewCommandNoGlobals("annex", "copy", "--to", "origin").RunStdString(&git.RunOpts{Dir: repoPath})
 	if err != nil {
 		return err
 	}
 
-	_, _, err = git.NewCommand(git.DefaultContext, "annex", "sync", "--no-content").RunStdString(&git.RunOpts{Dir: repoPath})
+	_, _, err = git.NewCommandNoGlobals("annex", "sync", "--no-content").RunStdString(&git.RunOpts{Dir: repoPath})
 	if err != nil {
 		return err
 	}
@@ -654,7 +937,7 @@ func doInitAnnexRepository(repoPath string) error {
 
 	// 'git annex init'
 	// 'gitea-annex-test' is there to avoid the nuisance comment getting stored.
-	err = git.NewCommand(git.DefaultContext, "annex", "init", "gitea-annex-test").Run(&git.RunOpts{Dir: repoPath})
+	err = git.NewCommandNoGlobals("annex", "init", "gitea-annex-test").Run(&git.RunOpts{Dir: repoPath})
 	if err != nil {
 		return err
 	}
@@ -700,7 +983,7 @@ func doInitRemoteAnnexRepository(t *testing.T, repoURL *url.URL) error {
 		return err
 	}
 
-	_, _, err = git.NewCommand(git.DefaultContext, "annex", "sync", "--content").RunStdString(&git.RunOpts{Dir: repoPath})
+	_, _, err = git.NewCommandNoGlobals("annex", "sync", "--content").RunStdString(&git.RunOpts{Dir: repoPath})
 	if err != nil {
 		return err
 	}
@@ -748,4 +1031,53 @@ func withAnnexCtxKeyFile(t *testing.T, ctx APITestContext, callback func()) {
 	os.Setenv("GIT_ANNEX_USE_GIT_SSH", "1") // withKeyFile works by setting GIT_SSH_COMMAND, but git-annex only respects that if this is set
 
 	withCtxKeyFile(t, ctx, callback)
+}
+
+/* like withKeyFile(), but sets HTTP credentials instead of SSH credentials.
+
+   It does this by temporarily arranging for through `git config --global`
+   to use git-credential-store(1) with the password written to a tempfile.
+
+   This is the only reliable way to pass HTTP credentials non-interactively
+   to git-annex.  See https://git-annex.branchable.com/bugs/http_remotes_ignore_annex.web-options_--netrc/#comment-b5a299e9826b322f2d85c96d4929a430
+   for joeyh's proclamation on the subject.
+
+   This **is only effective** when used around git.NewCommandNoGlobals() calls.
+   git.NewCommand() disables credential.helper as a precaution (see modules/git/git.go).
+
+   In contrast, the tests in git_test.go put the password in the remote's URL like
+   `git config remote.origin.url http://user2:password@localhost:3003/user2/repo-name.git`,
+   writing the password in repoPath+"/.git/config". That would be equally good, except
+   that git-annex ignores it!
+*/
+func withAnnexCtxHTTPPassword(t *testing.T, u *url.URL, ctx APITestContext, callback func()) {
+
+	credentialedURL := *u
+	credentialedURL.User = url.UserPassword(ctx.Username, userPassword) // NB: all test users use the same password
+
+	creds := path.Join(t.TempDir(), "creds")
+	require.NoError(t, os.WriteFile(creds, []byte(credentialedURL.String()), 0600))
+
+	originalCredentialHelper, _, err := git.NewCommandNoGlobals("config", "--global", "credential.helper").RunStdString(&git.RunOpts{})
+	if err != nil && !err.IsExitCode(1) {
+		// ignore the 'error' thrown when credential.helper is unset (when git config returns 1)
+		// but catch all others
+		require.NoError(t, err)
+	}
+	hasOriginalCredentialHelper := (err == nil)
+
+	_, _, err = git.NewCommandNoGlobals("config", "--global", "credential.helper", fmt.Sprintf("store --file=%s", creds)).RunStdString(&git.RunOpts{})
+	require.NoError(t, err)
+
+	defer (func() {
+		// reset
+		if hasOriginalCredentialHelper {
+			_, _, err = git.NewCommandNoGlobals("config", "--global", "credential.helper", originalCredentialHelper).RunStdString(&git.RunOpts{})
+		} else {
+			_, _, err = git.NewCommandNoGlobals("config", "--global", "--unset", "credential.helper").RunStdString(&git.RunOpts{})
+		}
+		require.NoError(t, err)
+	})()
+
+	callback()
 }

--- a/tests/integration/git_helper_for_declarative_test.go
+++ b/tests/integration/git_helper_for_declarative_test.go
@@ -71,6 +71,13 @@ func withKeyFile(t *testing.T, keyname string, callback func(string)) {
 	callback(keyFile)
 }
 
+func createHTTPUrl(gitPath string, u *url.URL) *url.URL {
+	// this assumes u contains the HTTP base URL that Gitea is running on
+	u2 := *u
+	u2.Path = gitPath
+	return &u2
+}
+
 func createSSHUrl(gitPath string, u *url.URL) *url.URL {
 	u2 := *u
 	u2.Scheme = "ssh"


### PR DESCRIPTION
This makes `git clone https://...... && git annex get` function, so that datasets can be shared widely, without the big roadblock of necessarily having to create accounts or ssh keys for users.

Fixes https://github.com/neuropoly/gitea/issues/3

I don't think git-annex supports uploading over http, and
neither does this. If it turns out it does I'll revise this.

Ref: https://git-annex.branchable.com/tips/setup_a_public_repository_on_a_web_site/
but this skip several of those instructions:

* they assume you're deploying to a non-bare repository
* gitea already takes care of the update-server-info hook
* we want to enforce gitea's access control so we don't
  use core.sharedRepository

**Follows #18**